### PR TITLE
If the password is empty lets give a good error instead of

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -16,7 +16,7 @@
 #
 # [*password*]
 #   Password for authentication to private Docker registry. Leave undef if
-#   auth is not required.
+#   auth is not required.  Password can not be blank.
 #
 # [*email*]
 #   Email for registration to private Docker registry. Leave undef if
@@ -43,6 +43,7 @@ define docker::registry(
 
   if $ensure == 'present' {
     if $username != undef and $password != undef and $email != undef {
+      validate_slength($password, 255, 1)
       $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     }

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -44,6 +44,15 @@ describe 'docker::registry', :type => :define do
     it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_user('testuser').with_environment('password=secret') }
   end
 
+  context 'with username => user1, and password => empty, and email => user1@example.io and local_user => testuser' do
+    let(:params) { { 'username' => 'user1', 'password' => '', 'email' => 'user1@example.io', 'local_user' => 'testuser' } }
+    it do
+        expect {
+            should have_exec_resource_count(0)
+        }.to raise_error(Puppet::Error)
+    end
+  end
+
   context 'with an invalid ensure value' do
     let(:params) { { 'ensure' => 'not present or absent' } }
     it do


### PR DESCRIPTION
$password= invalid.  Which is a bit cryptic in puppet logs
